### PR TITLE
gc: add delete range parameters to gc request

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -54,6 +54,18 @@ func declareKeysGC(
 			Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 		})
 	}
+	// For clear subrange operations we only need to obtain locks if we are
+	// removing multiple keys and not when we remove multiple versions.
+	// Versions case is not different from points deletions as we never remove
+	// data above gc threshold.
+	// Multiple keys versions is similar to ClearRangeKey case below where we
+	// must prevent writers adding any keys in the middle of this range.
+	if rk := gcr.ClearSubRangeKey; rk != nil {
+		if rk.EndKey != nil {
+			latchSpans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: rk.StartKey, EndKey: rk.EndKey},
+				hlc.MaxTimestamp)
+		}
+	}
 	// For ClearRangeKey request we still obtain a wide write lock as we don't
 	// expect any operations running on the range.
 	if rk := gcr.ClearRangeKey; rk != nil {
@@ -184,6 +196,23 @@ func GC(
 		}
 	}
 
+	// Garbage collect specified keys defined by clear range subranges i.e. parts
+	// of the whole range containing no more data.
+	if rk := args.ClearSubRangeKey; rk != nil {
+		// To avoid unnecessary write locks if we only remove part of history for
+		// the single key we pass it as range without end bound. Then we can create
+		// a safe range that only spans from particular timestamp up to the next
+		// key.
+		endKey := rk.EndKey
+		if endKey == nil {
+			endKey = rk.StartKey.Next()
+		}
+		if err := storage.MVCCGarbageCollectPointsWithClearRange(ctx, readWriter, cArgs.Stats,
+			rk.StartKey, endKey, rk.StartKeyTimestamp, cArgs.EvalCtx.GetGCThreshold()); err != nil {
+			return result.Result{}, err
+		}
+	}
+	
 	// Garbage collect range keys. Note that we pass latch range boundaries for
 	// each key as we may need to merge range keys with adjacent ones, but we
 	// are restricted on how far we are allowed to read.

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -388,11 +388,11 @@ type uniformDistSpec struct {
 	deleteFrac                       float64
 	// keysPerValue parameters determine number of versions for a key. This number
 	// includes tombstones and intents which may be present on top of the history.
-	keysPerValueMin, keysPerValueMax int
+	versionsPerKeyMin, versionsPerKeyMax int
 	// Fractions define how likely is that a key will belong to one of categories.
 	// If we only had a single version for each key, then that would be fraction
 	// of total number of objects, but if we have many versions, this value would
-	// roughly be total objects/avg(keysPerValueMin, keysPerValueMax) * frac.
+	// roughly be total objects/avg(versionsPerKeyMin, versionsPerKeyMax) * frac.
 	intentFrac, oldIntentFrac float64
 	rangeKeyFrac              float64
 }
@@ -414,7 +414,7 @@ func (ds uniformDistSpec) dist(maxRows int, rng *rand.Rand) dataDistribution {
 		uniformTableStringKeyDistribution(ds.desc().StartKey.AsRawKey(), ds.keySuffixMin,
 			ds.keySuffixMax, rng),
 		uniformValueStringDistribution(ds.valueLenMin, ds.valueLenMax, ds.deleteFrac, rng),
-		uniformValuesPerKey(ds.keysPerValueMin, ds.keysPerValueMax, rng),
+		uniformVersionsPerKey(ds.versionsPerKeyMin, ds.versionsPerKeyMax, rng),
 		ds.intentFrac,
 		ds.oldIntentFrac,
 		ds.rangeKeyFrac,
@@ -436,12 +436,12 @@ func (ds uniformDistSpec) String() string {
 		"ts=[%d,%d],"+
 			"keySuffix=[%d,%d],"+
 			"valueLen=[%d,%d],"+
-			"keysPerValue=[%d,%d],"+
+			"versionsPerKey=[%d,%d],"+
 			"deleteFrac=%f,intentFrac=%f,oldIntentFrac=%f,rangeFrac=%f",
 		ds.tsSecFrom, ds.tsSecTo,
 		ds.keySuffixMin, ds.keySuffixMax,
 		ds.valueLenMin, ds.valueLenMax,
-		ds.keysPerValueMin, ds.keysPerValueMax,
+		ds.versionsPerKeyMin, ds.versionsPerKeyMax,
 		ds.deleteFrac, ds.intentFrac, ds.oldIntentFrac, ds.rangeKeyFrac)
 }
 
@@ -497,7 +497,7 @@ func uniformValueStringDistribution(
 	}
 }
 
-func uniformValuesPerKey(valuesPerKeyMin, valuesPerKeyMax int, rng *rand.Rand) func() int {
+func uniformVersionsPerKey(valuesPerKeyMin, valuesPerKeyMax int, rng *rand.Rand) func() int {
 	if valuesPerKeyMin > valuesPerKeyMax {
 		panic(fmt.Errorf("min (%d) > max (%d)", valuesPerKeyMin, valuesPerKeyMax))
 	}

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -268,9 +268,9 @@ type Info struct {
 	// ClearRangeKeyFailures reports 1 if GC identified a possibility to collect
 	// with ClearRange operation, but request failed.
 	ClearRangeKeyFailures int
-	// FullRangeDeleteOperations is 1 if fast path delete range request was successfully used to
-	// remove all replicated data from a range.
-	FullRangeDeleteOperations int64
+	// ClearConsecutiveKeysOperations is a number of clear range requests used to
+	// remove consecutive keys.
+	ClearConsecutiveKeysOperations int
 }
 
 // RunOptions contains collection of limits that GC run applies when performing operations
@@ -510,7 +510,7 @@ func processReplicatedKeyRange(
 		}
 
 		for ; ; it.step() {
-			var upd gcBatchCounters
+			var upd gcInfoUpdate
 			var err error
 
 			s, ok := it.state()
@@ -583,10 +583,18 @@ type gcBatchCounters struct {
 	versionsAffected int
 }
 
-func (c gcBatchCounters) updateGcInfo(info *Info) {
-	info.AffectedVersionsKeyBytes += c.keyBytes
-	info.AffectedVersionsValBytes += c.valBytes
-	info.NumKeysAffected += c.keysAffected
+// gcInfoUpdate accumulates changes to gcInfo when processing a single key
+// version.
+type gcInfoUpdate struct {
+	gcBatchCounters
+	clearRangeOps int
+}
+
+func (u gcInfoUpdate) updateGcInfo(info *Info) {
+	info.AffectedVersionsKeyBytes += u.keyBytes
+	info.AffectedVersionsValBytes += u.valBytes
+	info.NumKeysAffected += u.keysAffected
+	info.ClearConsecutiveKeysOperations += u.clearRangeOps
 }
 
 func (c *gcBatchCounters) add(o gcBatchCounters) {
@@ -678,7 +686,7 @@ func (b *gcKeyBatcher) String() string {
 
 func (b *gcKeyBatcher) foundNonGCableData(
 	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	b.prevWasNewest = isNewestPoint
 	if !b.clearRangeEnabled {
 		return counterUpdate, nil
@@ -688,7 +696,7 @@ func (b *gcKeyBatcher) foundNonGCableData(
 	// and flush them as we reached end of current consecutive key span.
 	counterUpdate, err = b.maybeFlushPendingBatches(ctx)
 	if err != nil {
-		return gcBatchCounters{}, err
+		return gcInfoUpdate{}, err
 	}
 	b.clearRangeCounters = gcBatchCounters{}
 
@@ -700,7 +708,7 @@ func (b *gcKeyBatcher) foundNonGCableData(
 
 func (b *gcKeyBatcher) foundGarbage(
 	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	// If we are restarting clear range collection, then last points batch might
 	// be reverted to partial at the time of flush. We will save its
 	// pre-clear-range state and use for GC stats update.
@@ -719,9 +727,11 @@ func (b *gcKeyBatcher) foundGarbage(
 			// If clear range is disabled, flush batches immediately as they are
 			// formed.
 			if !b.clearRangeEnabled {
-				if counterUpdate, err = b.flushPointsBatch(ctx, &b.pointsBatches[i]); err != nil {
-					return gcBatchCounters{}, err
+				upd, err := b.flushPointsBatch(ctx, &b.pointsBatches[i])
+				if err != nil {
+					return gcInfoUpdate{}, err
 				}
+				counterUpdate.add(upd)
 			} else {
 				b.pointsBatches = append(b.pointsBatches, pointsBatch{})
 				i++
@@ -755,7 +765,7 @@ func (b *gcKeyBatcher) foundGarbage(
 			// to flush oldest batch to protect node from exhausting memory.
 			lastKey, update, err := b.flushOldestPointBatches(ctx, 1)
 			if err != nil {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			counterUpdate.add(update)
 			// If oldest batch intersected with currently tracked clear range request
@@ -807,7 +817,7 @@ func (b *gcKeyBatcher) foundGarbage(
 //     except for last are flushed
 func (b *gcKeyBatcher) maybeFlushPendingBatches(
 	ctx context.Context,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	// Find where in first points batch is start key and flush "prefix".
 	if b.clearRangeEnabled && b.clearRangeCounters.versionsAffected >= b.clearRangeMinKeys {
 		//fmt.Printf("flushing range batch on live data\n")
@@ -825,7 +835,7 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			b.pointsBatches[0].gcBatchCounters = b.partialPointBatchCounters
 			upd, err := b.flushPointsBatch(ctx, &b.pointsBatches[0])
 			if err != nil {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			counterUpdate.add(upd)
 		}
@@ -838,7 +848,7 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			EndKey:            b.clearRangeEndKey,
 		}); err != nil {
 			if errors.Is(err, ctx.Err()) {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			// Even though we are batching the GC process, it's
 			// safe to continue because we bumped the GC
@@ -847,12 +857,13 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			log.Warningf(ctx, "failed to GC keys with clear range: %v", err)
 		}
 		counterUpdate.add(b.clearRangeCounters)
+		counterUpdate.clearRangeOps++
 		b.totalMemUsed = 0
 	} else if flushTo := len(b.pointsBatches) - 1; flushTo > 0 {
 		//fmt.Printf("flushing points batch on live data\n")
 		lastKey, update, err := b.flushOldestPointBatches(ctx, flushTo)
 		if err != nil {
-			return gcBatchCounters{}, err
+			return gcInfoUpdate{}, err
 		}
 		counterUpdate.add(update)
 		b.clearRangeEndKey = lastKey[:len(lastKey):len(lastKey)].Next()
@@ -908,9 +919,9 @@ func (b *gcKeyBatcher) flushPointsBatch(
 
 func (b *gcKeyBatcher) flushLastBatch(
 	ctx context.Context,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	if len(b.pointsBatches[0].batchGCKeys) == 0 {
-		return gcBatchCounters{}, nil
+		return gcInfoUpdate{}, nil
 	}
 	b.pointsBatches = append(b.pointsBatches, pointsBatch{})
 	return b.maybeFlushPendingBatches(ctx)

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -163,8 +163,14 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			it := makeGCIterator(&desc, snap, tc.gcThreshold, false)
-			defer it.close()
+			mvccIt := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				LowerBound: desc.StartKey.AsRawKey(),
+				UpperBound: desc.EndKey.AsRawKey(),
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			})
+			mvccIt.SeekLT(storage.MVCCKey{Key: desc.EndKey.AsRawKey()})
+			defer mvccIt.Close()
+			it := makeGCIterator(mvccIt, tc.gcThreshold)
 			expectations := tc.expectations
 			for i, ex := range expectations {
 				s, ok := it.state()

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -150,7 +150,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys, nil, nil)
+							err := gcer.GC(ctx, batchGCKeys, nil, nil, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -209,7 +209,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -46,47 +46,47 @@ var (
 		tsSecFrom: 1, tsSecTo: 100,
 		keySuffixMin: 2, keySuffixMax: 6,
 		valueLenMin: 1, valueLenMax: 1,
-		deleteFrac:      0,
-		keysPerValueMin: 1, keysPerValueMax: 2,
+		deleteFrac:        0,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 2,
 		intentFrac: .1,
 	}
 	someVersionsMidSizeRows = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
 		keySuffixMin: 8, keySuffixMax: 8,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1, keysPerValueMax: 100,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 100,
 		intentFrac: .1,
 	}
 	lotsOfVersionsMidSizeRows = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1000, keysPerValueMax: 1000000,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1000, versionsPerKeyMax: 1000000,
 		intentFrac: .1,
 	}
 	// This spec is identical to someVersionsMidSizeRows except for number of
 	// intents.
 	someVersionsMidSizeRowsLotsOfIntents = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1, keysPerValueMax: 100,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 100,
 		intentFrac: 1,
 	}
 	someVersionsWithSomeRangeKeys = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
 		tsSecMinIntent: 70, tsSecOldIntentTo: 85,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1,
-		keysPerValueMax: 100,
-		intentFrac:      .1,
-		oldIntentFrac:   .1,
-		rangeKeyFrac:    .1,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1,
+		versionsPerKeyMax: 100,
+		intentFrac:        .1,
+		oldIntentFrac:     .1,
+		rangeKeyFrac:      .1,
 	}
 
 	// smallEngineBlocks configures Pebble with a block size of 1 byte, to provoke
@@ -278,6 +278,7 @@ func TestNewVsInvariants(t *testing.T) {
 		t.Run(fmt.Sprintf("%v@%v,ttl=%vsec", tc.ds, tc.now, tc.ttlSec), func(t *testing.T) {
 			rng, seed := randutil.NewTestRand()
 			t.Logf("Using subtest seed: %d", seed)
+			//rng := randutil.NewTestRandWithSeed(4249930301727204042)
 
 			desc := tc.ds.desc()
 			eng := storage.NewDefaultInMemForTesting(storage.If(smallEngineBlocks, storage.BlockSize(1)))
@@ -297,6 +298,7 @@ func TestNewVsInvariants(t *testing.T) {
 				gcThreshold, RunOptions{
 					IntentAgeThreshold:  intentAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
+					ClearRangeMinKeys:   100,
 				}, ttl,
 				&gcer,
 				gcer.resolveIntents,
@@ -316,12 +318,23 @@ func TestNewVsInvariants(t *testing.T) {
 				_, err := storage.MVCCResolveWriteIntent(ctx, eng, &stats, l)
 				require.NoError(t, err, "failed to resolve intent")
 			}
+			for _, cr := range gcer.clearSubRangeKeys() {
+				require.NoError(t,
+					storage.MVCCGarbageCollectPointsWithClearRange(ctx, eng, &stats, cr.StartKey, cr.EndKey,
+						cr.StartKeyTimestamp, gcThreshold))
+			}
 			for _, batch := range gcer.rangeKeyBatches() {
 				rangeKeys := makeCollectableGCRangesFromGCRequests(desc.StartKey.AsRawKey(),
 					desc.EndKey.AsRawKey(), batch)
 				require.NoError(t,
 					storage.MVCCGarbageCollectRangeKeys(ctx, eng, &stats, rangeKeys))
 			}
+			if len(gcer.gcClearRangeKeys) > 0 {
+				panic("Clear range happened")
+			}
+
+			fmt.Printf("GCER requests\nPoint keys: %d\nSubranges: %d\nRange keys: %d\n",
+				len(gcer.gcKeys), len(gcer.gcClearSubRangeKeys), len(gcer.gcRangeKeyBatches))
 
 			assertLiveData(t, eng, beforeGC, *desc, tc.now, gcThreshold, intentThreshold, ttl,
 				gcInfoNew)
@@ -738,7 +751,8 @@ func mergeRanges(fragments [][]storage.MVCCRangeKeyValue) []storage.MVCCRangeKey
 }
 
 type fakeGCer struct {
-	gcKeys map[string]roachpb.GCRequest_GCKey
+	gcKeys          map[string]roachpb.GCRequest_GCKey
+	gcPointsBatches [][]roachpb.GCRequest_GCKey
 	// fake GCer stores range key batches as it since we need to be able to
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
@@ -774,12 +788,22 @@ func (f *fakeGCer) GC(
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
 	}
-	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	if keys != nil {
+		f.gcPointsBatches = append(f.gcPointsBatches, keys)
+	}
+	if rangeKeys != nil {
+		f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	}
 	if clearRangeKey != nil {
 		f.gcClearRangeKeys = append(f.gcClearRangeKeys, *clearRangeKey)
 	}
 	if clearSubRangeKey != nil {
-		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, *clearSubRangeKey)
+		// Cloning keys because GC can reuse key slices for range keys.
+		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, roachpb.GCRequest_GCClearSubRangeKey{
+			StartKey:          clearSubRangeKey.StartKey.Clone(),
+			StartKeyTimestamp: clearSubRangeKey.StartKeyTimestamp,
+			EndKey:            clearSubRangeKey.EndKey.Clone(),
+		})
 	}
 	return nil
 }
@@ -829,6 +853,14 @@ func (f *fakeGCer) rangeKeys() []roachpb.GCRequest_GCRangeKey {
 	return reqs
 }
 
+func (f *fakeGCer) clearRangeKeys() []roachpb.GCRequest_GCClearRangeKey {
+	return f.gcClearRangeKeys
+}
+
+func (f *fakeGCer) clearSubRangeKeys() []roachpb.GCRequest_GCClearSubRangeKey {
+	return f.gcClearSubRangeKeys
+}
+
 func intentLess(a, b *roachpb.Intent) bool {
 	cmp := a.Key.Compare(b.Key)
 	switch {
@@ -853,25 +885,36 @@ func makeCollectableGCRangesFromGCRequests(
 ) []storage.CollectableGCRangeKey {
 	collectableKeys := make([]storage.CollectableGCRangeKey, len(rangeKeys))
 	for i, rk := range rangeKeys {
-		leftPeekBound := rk.StartKey.Prevish(roachpb.PrevishKeyLength)
-		if len(rangeStart) > 0 && leftPeekBound.Compare(rangeStart) <= 0 {
-			leftPeekBound = rangeStart
-		}
-		rightPeekBound := rk.EndKey.Next()
-		if len(rangeEnd) > 0 && rightPeekBound.Compare(rangeEnd) >= 0 {
-			rightPeekBound = rangeEnd
-		}
+		peekBounds := expandRangeSpan(roachpb.Span{
+			Key:    rk.StartKey,
+			EndKey: rk.EndKey,
+		}, roachpb.Span{
+			Key:    rangeStart,
+			EndKey: rangeEnd,
+		})
 		collectableKeys[i] = storage.CollectableGCRangeKey{
 			MVCCRangeKey: storage.MVCCRangeKey{
 				StartKey:  rk.StartKey,
 				EndKey:    rk.EndKey,
 				Timestamp: rk.Timestamp,
 			},
-			LatchSpan: roachpb.Span{
-				Key:    leftPeekBound,
-				EndKey: rightPeekBound,
-			},
+			LatchSpan: peekBounds,
 		}
 	}
 	return collectableKeys
+}
+
+func expandRangeSpan(rangeKey, limits roachpb.Span) roachpb.Span {
+	leftPeekBound := rangeKey.Key.Prevish(roachpb.PrevishKeyLength)
+	if len(limits.Key) > 0 && leftPeekBound.Compare(limits.Key) <= 0 {
+		leftPeekBound = limits.Key
+	}
+	rightPeekBound := rangeKey.EndKey.Next()
+	if len(limits.EndKey) > 0 && rightPeekBound.Compare(limits.EndKey) >= 0 {
+		rightPeekBound = limits.EndKey
+	}
+	return roachpb.Span{
+		Key:    leftPeekBound,
+		EndKey: rightPeekBound,
+	}
 }

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -742,12 +742,13 @@ type fakeGCer struct {
 	// fake GCer stores range key batches as it since we need to be able to
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
-	gcRangeKeyBatches [][]roachpb.GCRequest_GCRangeKey
-	gcClearRangeKeys  []roachpb.GCRequest_GCClearRangeKey
-	threshold         Threshold
-	intents           []roachpb.Intent
-	batches           [][]roachpb.Intent
-	txnIntents        []txnIntents
+	gcRangeKeyBatches   [][]roachpb.GCRequest_GCRangeKey
+	gcClearRangeKeys    []roachpb.GCRequest_GCClearRangeKey
+	gcClearSubRangeKeys []roachpb.GCRequest_GCClearSubRangeKey
+	threshold           Threshold
+	intents             []roachpb.Intent
+	batches             [][]roachpb.Intent
+	txnIntents          []txnIntents
 }
 
 func makeFakeGCer() fakeGCer {
@@ -768,6 +769,7 @@ func (f *fakeGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	rangeKeys []roachpb.GCRequest_GCRangeKey,
 	clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
+	clearSubRangeKey *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
@@ -775,6 +777,9 @@ func (f *fakeGCer) GC(
 	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
 	if clearRangeKey != nil {
 		f.gcClearRangeKeys = append(f.gcClearRangeKeys, *clearRangeKey)
+	}
+	if clearSubRangeKey != nil {
+		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, *clearSubRangeKey)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -60,6 +60,7 @@ func (c *collectingGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	_ []roachpb.GCRequest_GCRangeKey,
 	_ *roachpb.GCRequest_GCClearRangeKey,
+	_ *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
 	c.keys = append(c.keys, keys)
 	return nil

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1316,6 +1316,12 @@ sub-level and file counts.`,
 		Measurement: "Range Keys",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaGCClearConsecutiveKeys = metric.Metadata{
+		Name:        "queue.gc.info.numclearconsecutivekeys",
+		Help:        "Number of clear range requests to remove consecutive keys issued by GC",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaGCIntentsConsidered = metric.Metadata{
 		Name:        "queue.gc.info.intentsconsidered",
 		Help:        "Number of 'old' intents",
@@ -1889,6 +1895,7 @@ type StoreMetrics struct {
 	// GCInfo cumulative totals.
 	GCNumKeysAffected            *metric.Counter
 	GCNumRangeKeysAffected       *metric.Counter
+	GCClearConsecutiveKeys       *metric.Counter
 	GCIntentsConsidered          *metric.Counter
 	GCIntentTxns                 *metric.Counter
 	GCTransactionSpanScanned     *metric.Counter
@@ -2426,6 +2433,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		// GCInfo cumulative totals.
 		GCNumKeysAffected:            metric.NewCounter(metaGCNumKeysAffected),
 		GCNumRangeKeysAffected:       metric.NewCounter(metaGCNumRangeKeysAffected),
+		GCClearConsecutiveKeys:       metric.NewCounter(metaGCClearConsecutiveKeys),
 		GCIntentsConsidered:          metric.NewCounter(metaGCIntentsConsidered),
 		GCIntentTxns:                 metric.NewCounter(metaGCIntentTxns),
 		GCTransactionSpanScanned:     metric.NewCounter(metaGCTransactionSpanScanned),

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -681,6 +681,7 @@ func (mgcq *mvccGCQueue) process(
 	maxIntentsPerCleanupBatch := gc.MaxIntentsPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	maxIntentKeyBytesPerCleanupBatch := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	txnCleanupThreshold := gc.TxnCleanupThreshold.Get(&repl.store.ClusterSettings().SV)
+	minKeyNumberForClearRange := gc.MinKeyNumberForClearRange.Get(&repl.store.ClusterSettings().SV)
 
 	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold,
 		gc.RunOptions{
@@ -690,6 +691,7 @@ func (mgcq *mvccGCQueue) process(
 			TxnCleanupThreshold:                    txnCleanupThreshold,
 			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
 			IntentCleanupBatchTimeout:              mvccGCQueueIntentBatchTimeout,
+			ClearRangeMinKeys:                      minKeyNumberForClearRange,
 		},
 		conf.TTL(),
 		&replicaGCer{

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -785,6 +785,7 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 	metrics.GCResolveTotal.Inc(int64(info.ResolveTotal))
 	metrics.GCUsedClearRange.Inc(int64(info.ClearRangeKeyOperations))
 	metrics.GCFailedClearRange.Inc(int64(info.ClearRangeKeyFailures))
+	metrics.GCClearConsecutiveKeys.Inc(int64(info.ClearConsecutiveKeysOperations))
 }
 
 func (mgcq *mvccGCQueue) postProcessScheduled(

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -595,14 +595,16 @@ func (r *replicaGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	rangeKeys []roachpb.GCRequest_GCRangeKey,
 	clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
+	clearSubRangeKey *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
-	if len(keys) == 0 && len(rangeKeys) == 0 && clearRangeKey == nil {
+	if len(keys) == 0 && len(rangeKeys) == 0 && clearRangeKey == nil && clearSubRangeKey == nil {
 		return nil
 	}
 	req := r.template()
 	req.Keys = keys
 	req.RangeKeys = rangeKeys
 	req.ClearRangeKey = clearRangeKey
+	req.ClearSubRangeKey = clearSubRangeKey
 	return r.send(ctx, req)
 }
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -434,6 +434,7 @@ func IterateReplicaKeySpans(
 type IterateOptions struct {
 	CombineRangesAndPoints bool
 	Reverse                bool
+	ExcludeUserKeySpan     bool
 }
 
 // IterateMVCCReplicaKeySpans iterates over replica's key spans in the similar
@@ -449,6 +450,9 @@ func IterateMVCCReplicaKeySpans(
 		panic("reader must provide consistent iterators")
 	}
 	spans := MakeReplicatedKeySpansExceptLockTable(desc)
+	if options.ExcludeUserKeySpan {
+		spans = MakeReplicatedKeySpansExcludingUserAndLockTable(desc)
+	}
 	if options.Reverse {
 		spanMax := len(spans) - 1
 		for i := 0; i < len(spans)/2; i++ {

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -406,16 +406,79 @@ func IterateReplicaKeySpans(
 	keyTypes := []storage.IterKeyType{storage.IterKeyTypePointsOnly, storage.IterKeyTypeRangesOnly}
 	for _, span := range spans {
 		for _, keyType := range keyTypes {
-			iter := reader.NewEngineIterator(storage.IterOptions{
-				KeyTypes:   keyType,
-				LowerBound: span.Key,
-				UpperBound: span.EndKey,
-			})
-			ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: span.Key})
-			if err == nil && ok {
-				err = visitor(iter, span, keyType)
+			err := func() error {
+				iter := reader.NewEngineIterator(storage.IterOptions{
+					KeyTypes:   keyType,
+					LowerBound: span.Key,
+					UpperBound: span.EndKey,
+				})
+				defer iter.Close()
+				ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: span.Key})
+				if err == nil && ok {
+					err = visitor(iter, span, keyType)
+				}
+				return err
+			}()
+			if err != nil {
+				return iterutil.Map(err)
 			}
-			iter.Close()
+		}
+	}
+	return nil
+}
+
+// IterateOptions instructs how points and ranges should be presented to visitor
+// and if iterators should be visited in forward or reverse order.
+// Reverse iterator are also positioned at the end of the range prior to being
+// passed to visitor.
+type IterateOptions struct {
+	CombineRangesAndPoints bool
+	Reverse                bool
+}
+
+// IterateMVCCReplicaKeySpans iterates over replica's key spans in the similar
+// way to IterateReplicaKeySpans, but uses MVCCIterator and gives additional
+// options to create reverse iterators and to combine keys are ranges.
+func IterateMVCCReplicaKeySpans(
+	desc *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	options IterateOptions,
+	visitor func(storage.MVCCIterator, roachpb.Span, storage.IterKeyType) error,
+) error {
+	if !reader.ConsistentIterators() {
+		panic("reader must provide consistent iterators")
+	}
+	spans := MakeReplicatedKeySpansExceptLockTable(desc)
+	if options.Reverse {
+		spanMax := len(spans) - 1
+		for i := 0; i < len(spans)/2; i++ {
+			spans[spanMax-i], spans[i] = spans[i], spans[spanMax-i]
+		}
+	}
+	keyTypes := []storage.IterKeyType{storage.IterKeyTypePointsOnly, storage.IterKeyTypeRangesOnly}
+	if options.CombineRangesAndPoints {
+		keyTypes = []storage.IterKeyType{storage.IterKeyTypePointsAndRanges}
+	}
+	for _, span := range spans {
+		for _, keyType := range keyTypes {
+			err := func() error {
+				iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+					LowerBound: span.Key,
+					UpperBound: span.EndKey,
+					KeyTypes:   keyType,
+				})
+				defer iter.Close()
+				if options.Reverse {
+					iter.SeekLT(storage.MakeMVCCMetadataKey(span.EndKey))
+				} else {
+					iter.SeekGE(storage.MakeMVCCMetadataKey(span.Key))
+				}
+				ok, err := iter.Valid()
+				if err == nil && ok {
+					err = visitor(iter, span, keyType)
+				}
+				return err
+			}()
 			if err != nil {
 				return iterutil.Map(err)
 			}

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -148,52 +148,53 @@ func verifyRDReplicatedOnlyMVCCIter(
 			}, hlc.Timestamp{WallTime: 42})
 			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaMVCCDataIterator(desc, readWriter, ReplicaDataIteratorOptions{
-			Reverse:  reverse,
-			IterKind: storage.MVCCKeyAndIntentsIterKind,
-			KeyTypes: storage.IterKeyTypePointsAndRanges,
-		})
-		defer iter.Close()
-		next := iter.Next
-		if reverse {
-			next = iter.Prev
-		}
 		var rangeStart roachpb.Key
 		actualKeys := []storage.MVCCKey{}
 		actualRanges := []storage.MVCCRangeKey{}
-		for {
-			ok, err := iter.Valid()
-			require.NoError(t, err)
-			if !ok {
-				break
-			}
-			p, r := iter.HasPointAndRange()
-			if p {
-				if !reverse {
-					actualKeys = append(actualKeys, iter.Key())
-				} else {
-					actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+		err := IterateMVCCReplicaKeySpans(desc, readWriter, IterateOptions{
+			CombineRangesAndPoints: false,
+			Reverse:                reverse,
+		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+			for {
+				ok, err := iter.Valid()
+				require.NoError(t, err)
+				if !ok {
+					break
 				}
-			}
-			if r {
-				rangeKeys := iter.RangeKeys().Clone()
-				if !rangeKeys.Bounds.Key.Equal(rangeStart) {
-					rangeStart = rangeKeys.Bounds.Key.Clone()
+				p, r := iter.HasPointAndRange()
+				if p {
 					if !reverse {
-						for _, v := range rangeKeys.Versions {
-							actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
-						}
+						actualKeys = append(actualKeys, iter.Key())
 					} else {
-						for i := rangeKeys.Len() - 1; i >= 0; i-- {
-							actualRanges = append([]storage.MVCCRangeKey{
-								rangeKeys.AsRangeKey(rangeKeys.Versions[i])},
-								actualRanges...)
+						actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+					}
+				}
+				if r {
+					rangeKeys := iter.RangeKeys().Clone()
+					if !rangeKeys.Bounds.Key.Equal(rangeStart) {
+						rangeStart = rangeKeys.Bounds.Key.Clone()
+						if !reverse {
+							for _, v := range rangeKeys.Versions {
+								actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
+							}
+						} else {
+							for i := rangeKeys.Len() - 1; i >= 0; i-- {
+								actualRanges = append([]storage.MVCCRangeKey{
+									rangeKeys.AsRangeKey(rangeKeys.Versions[i]),
+								}, actualRanges...)
+							}
 						}
 					}
 				}
+				if reverse {
+					iter.Prev()
+				} else {
+					iter.Next()
+				}
 			}
-			next()
-		}
+			return nil
+		})
+		require.NoError(t, err, "visitor failed")
 		require.Equal(t, expectedKeys, actualKeys)
 		require.Equal(t, expectedRangeKeys, actualRanges)
 	}
@@ -521,5 +522,99 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 				require.NoError(b, err)
 			}
 		}
+	}
+}
+
+func TestIterateMVCCReplicaKeySpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set up a new engine and write a single range key across the entire span.
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	require.NoError(t, eng.PutEngineRangeKey(keys.MinKey.Next(), keys.MaxKey, []byte{1}, []byte{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("a"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("c"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+
+	// Use a snapshot for the iteration, because we need consistent
+	// iterators.
+	snapshot := eng.NewSnapshot()
+	defer snapshot.Close()
+
+	// Iterate over three range descriptors, both replicated and unreplicated.
+	descs := []roachpb.RangeDescriptor{
+		{
+			RangeID:  1,
+			StartKey: roachpb.RKey("a"),
+			EndKey:   roachpb.RKey("b"),
+		},
+		{
+			RangeID:  2,
+			StartKey: roachpb.RKey("b"),
+			EndKey:   roachpb.RKey("c"),
+		},
+		{
+			RangeID:  3,
+			StartKey: roachpb.RKey("c"),
+			EndKey:   roachpb.RKey("d"),
+		},
+	}
+	for _, desc := range descs {
+		t.Run(desc.KeySpan().String(), func(t *testing.T) {
+			testutils.RunTrueAndFalse(t, "reverse", func(t *testing.T, reverse bool) {
+				expectedSpans := MakeReplicatedKeySpansExceptLockTable(&desc)
+				if reverse {
+					for i, j := 0, len(expectedSpans)-1; i < j; i, j = i+1, j-1 {
+						expectedSpans[i], expectedSpans[j] = expectedSpans[j], expectedSpans[i]
+					}
+				}
+
+				var actualSpans []roachpb.Span
+				require.NoError(t, IterateMVCCReplicaKeySpans(&desc, snapshot, IterateOptions{CombineRangesAndPoints: true, Reverse: reverse},
+					func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+						// We should never see any point keys.
+						require.Equal(t, storage.IterKeyTypePointsAndRanges, keyType)
+
+						// The iterator should already be positioned on the range key, which should
+						// span the entire key span and be the only range key.
+						bounds := iter.RangeBounds()
+						require.Equal(t, span, bounds)
+						actualSpans = append(actualSpans, bounds.Clone())
+
+						fmt.Printf("Iterating span: %s\n", span.String())
+
+						// Only user key spans are interesting.
+						if len(span.Key) == 1 {
+							p, r := iter.HasPointAndRange()
+							require.True(t, r, "must have range")
+							// When using forward iterator, we first land on range tombstone
+							// because point has a timestamp and its key is next.
+							// When using backward iterator, we land on point and range at the
+							// same time.
+							require.Equal(t, reverse, p, "has point")
+							if !reverse {
+								iter.Next()
+							} else {
+								iter.Prev()
+							}
+							ok, err := iter.Valid()
+							require.NoError(t, err)
+							require.True(t, ok)
+							p, r = iter.HasPointAndRange()
+							require.True(t, r, "must have range")
+							require.Equal(t, !reverse, p, "has point")
+						}
+						return nil
+					}))
+				require.Equal(t, expectedSpans, actualSpans)
+			})
+		})
 	}
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1010,6 +1010,18 @@ message GCRequest {
   // the request will fail.
   GCClearRangeKey clear_range_key = 7;
 
+  // GCClearSubRangeKey contains a range of GCd point keys to clear. Start
+  // of ranges starts at a key with a timestamp includive and ends with a
+  // key without timestamp exclusive. Resulting operations will delete data
+  // in range [start_key@ts, end_key).
+  // This operation doesn't remove range tombstones covered.
+  message GCClearSubRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp start_key_timestamp = 2 [(gogoproto.nullable) = false];
+    bytes end_key = 3 [(gogoproto.casttype) = "Key"];
+  }
+  GCClearSubRangeKey clear_sub_range_key = 8;
+  
   reserved 5;
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5305,6 +5305,143 @@ func CanGCEntireRange(
 	return coveredByRangeTombstones, nil
 }
 
+var emptyMetaToken enginepb.MVCCMetadata
+
+// MVCCGarbageCollectPointsWithClearRange removes garbage collected data falling under
+// ranges covered by rks. This function performs a check to ensure that no
+// non-deleted data (most recent or history with timestamp greater that
+// threshold) is being deleted.
+func MVCCGarbageCollectPointsWithClearRange(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	start, end roachpb.Key,
+	startTimestamp hlc.Timestamp,
+	gcThreshold hlc.Timestamp,
+) error {
+	var countKeys int64
+	var removedEntries int64
+	defer func(begin time.Time) {
+		// TODO(oleg): this could be misleading if GC fails, but this function still
+		// reports how many keys were GC'd. The approach is identical to what point
+		// key GC does for consistency, but both places could be improved.
+		log.Eventf(ctx,
+			"done with GC evaluation for clear range at %.2f keys/sec. Deleted %d entries",
+			countKeys, float64(countKeys)*1e9/float64(timeutil.Since(begin)), removedEntries)
+	}(timeutil.Now())
+
+	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+		KeyTypes:   IterKeyTypePointsAndRanges,
+	})
+	defer iter.Close()
+
+	iter.SeekGE(MVCCKey{Key: start})
+
+	var (
+		prevPointKey    MVCCKey
+		rangeTombstones MVCCRangeKeyStack
+	)
+
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+
+		hasPoint, hasRange := iter.HasPointAndRange()
+		if hasRange {
+			if iter.RangeKeyChanged() {
+				rangeTombstones = iter.RangeKeys().Clone()
+			}
+		} else {
+			rangeTombstones = MVCCRangeKeyStack{}
+		}
+
+		if hasPoint {
+			countKeys++
+			unsafeKey := iter.UnsafeKey()
+			newKey := !prevPointKey.Key.Equal(unsafeKey.Key)
+			if newKey {
+				prevPointKey.Key = unsafeKey.Key.Clone()
+				prevPointKey.Timestamp = hlc.Timestamp{}
+			}
+
+			// Skip keys that fall outside of range.
+			if unsafeKey.Compare(MVCCKey{Key: end}) >= 0 {
+				break
+			}
+			if unsafeKey.Compare(MVCCKey{Key: start, Timestamp: startTimestamp}) < 0 {
+				prevPointKey.Timestamp = unsafeKey.Timestamp
+				continue
+			}
+
+			if unsafeKey.Timestamp.IsEmpty() {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+			if gcThreshold.Less(unsafeKey.Timestamp) {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			// Unmarshal value to check if we are dealing with tombstone.
+			unsafeValRaw := iter.UnsafeValue()
+			unsafeVal, unsafeValOK, err := tryDecodeSimpleMVCCValue(unsafeValRaw)
+			if !unsafeValOK && err == nil {
+				unsafeVal, err = decodeExtendedMVCCValue(unsafeValRaw)
+			}
+			if err != nil {
+				return err
+			}
+
+			// Find timestamp covering current key.
+			coveredBy := prevPointKey.Timestamp
+			if rangeKeyCover, ok := rangeTombstones.FirstAtOrAbove(unsafeKey.Timestamp); ok {
+				// If there's a range between current value and value above
+				// use that timestamp.
+				if coveredBy.IsEmpty() || rangeKeyCover.Timestamp.Less(coveredBy) {
+					coveredBy = rangeKeyCover.Timestamp
+				}
+			}
+			isCovered := !coveredBy.IsEmpty() && coveredBy.LessEq(gcThreshold)
+
+			isTombstone := unsafeVal.IsTombstone()
+			validTill := coveredBy
+			if isTombstone {
+				validTill = unsafeKey.Timestamp
+			}
+
+			if !isCovered && !isTombstone {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			// Prevent deletion of values on gcThreshold.
+			if !isTombstone && unsafeKey.Timestamp.Equal(gcThreshold) {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			if ms != nil {
+				if newKey {
+					ms.Add(updateStatsOnGC(unsafeKey.Key, int64(EncodedMVCCKeyPrefixLength(unsafeKey.Key)), 0,
+						&emptyMetaToken, validTill.WallTime))
+				}
+				ms.Add(updateStatsOnGC(unsafeKey.Key, MVCCVersionTimestampSize, int64(len(unsafeValRaw)), nil,
+					validTill.WallTime))
+			}
+			prevPointKey.Timestamp = unsafeKey.Timestamp
+			removedEntries++
+		}
+	}
+
+	// If timestamp is not empty we delete subset of versions (this may be first
+	// key of requested range or full extent).
+	if err := rw.ClearMVCCVersions(MVCCKey{Key: start, Timestamp: startTimestamp}, MVCCKey{Key: end}); err != nil {
+		return err
+	}
+	return nil
+}
+
 // MVCCFindSplitKey finds a key from the given span such that the left side of
 // the split is roughly targetSize bytes. It only considers MVCC point keys, not
 // range keys. The returned key will never be chosen from the key ranges listed

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -119,6 +119,7 @@ var (
 // clear_time_range k=<key> end=<key> ts=<int>[,<int>] targetTs=<int>[,<int>] [clearRangeThreshold=<int>] [maxBatchSize=<int>] [maxBatchByteSize=<int>]
 //
 // gc_clear_range k=<key> end=<key> startTs=<int>[,<int>] ts=<int>[,<int>]
+// gc_points_clear_range k=<key> end=<key> startTs=<int>[,<int>] ts=<int>[,<int>]
 // replace_point_tombstones_with_range_tombstones k=<key> [end=<key>]
 //
 // sst_put            [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> [v=<string>]
@@ -689,25 +690,26 @@ var commands = map[string]cmd{
 	"check_intent":         {typReadOnly, cmdCheckIntent},
 	"add_lock":             {typLocksUpdate, cmdAddLock},
 
-	"clear":            {typDataUpdate, cmdClear},
-	"clear_range":      {typDataUpdate, cmdClearRange},
-	"clear_rangekey":   {typDataUpdate, cmdClearRangeKey},
-	"clear_time_range": {typDataUpdate, cmdClearTimeRange},
-	"cput":             {typDataUpdate, cmdCPut},
-	"del":              {typDataUpdate, cmdDelete},
-	"del_range":        {typDataUpdate, cmdDeleteRange},
-	"del_range_ts":     {typDataUpdate, cmdDeleteRangeTombstone},
-	"del_range_pred":   {typDataUpdate, cmdDeleteRangePredicate},
-	"export":           {typReadOnly, cmdExport},
-	"get":              {typReadOnly, cmdGet},
-	"gc_clear_range":   {typDataUpdate, cmdGCClearRange},
-	"increment":        {typDataUpdate, cmdIncrement},
-	"initput":          {typDataUpdate, cmdInitPut},
-	"merge":            {typDataUpdate, cmdMerge},
-	"put":              {typDataUpdate, cmdPut},
-	"put_rangekey":     {typDataUpdate, cmdPutRangeKey},
-	"scan":             {typReadOnly, cmdScan},
-	"is_span_empty":    {typReadOnly, cmdIsSpanEmpty},
+	"clear":                 {typDataUpdate, cmdClear},
+	"clear_range":           {typDataUpdate, cmdClearRange},
+	"clear_rangekey":        {typDataUpdate, cmdClearRangeKey},
+	"clear_time_range":      {typDataUpdate, cmdClearTimeRange},
+	"cput":                  {typDataUpdate, cmdCPut},
+	"del":                   {typDataUpdate, cmdDelete},
+	"del_range":             {typDataUpdate, cmdDeleteRange},
+	"del_range_ts":          {typDataUpdate, cmdDeleteRangeTombstone},
+	"del_range_pred":        {typDataUpdate, cmdDeleteRangePredicate},
+	"export":                {typReadOnly, cmdExport},
+	"get":                   {typReadOnly, cmdGet},
+	"gc_clear_range":        {typDataUpdate, cmdGCClearRange},
+	"gc_points_clear_range": {typDataUpdate, cmdGCPointsClearRange},
+	"increment":             {typDataUpdate, cmdIncrement},
+	"initput":               {typDataUpdate, cmdInitPut},
+	"merge":                 {typDataUpdate, cmdMerge},
+	"put":                   {typDataUpdate, cmdPut},
+	"put_rangekey":          {typDataUpdate, cmdPutRangeKey},
+	"scan":                  {typReadOnly, cmdScan},
+	"is_span_empty":         {typReadOnly, cmdIsSpanEmpty},
 
 	"iter_new":                    {typReadOnly, cmdIterNew},
 	"iter_new_incremental":        {typReadOnly, cmdIterNewIncremental}, // MVCCIncrementalIterator
@@ -1014,6 +1016,15 @@ func cmdGCClearRange(e *evalCtx) error {
 		cms, err := storage.ComputeStats(rw, key, endKey, 100e9)
 		require.NoError(e.t, err, "failed to compute range stats")
 		return storage.MVCCGarbageCollectWholeRange(e.ctx, rw, e.ms, key, endKey, gcTs, cms)
+	})
+}
+
+func cmdGCPointsClearRange(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	gcTs := e.getTs(nil)
+	startTs := e.getTsWithName("startTs")
+	return e.withWriter("gc_clear_range", func(rw storage.ReadWriter) error {
+		return storage.MVCCGarbageCollectPointsWithClearRange(e.ctx, rw, e.ms, key, endKey, startTs, gcTs)
 	})
 }
 

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
@@ -1,0 +1,98 @@
+run ok
+put k=A v=B ts=10
+----
+>> at end:
+data: "A"/10.000000000,0 -> /BYTES/B
+
+# Check that we can't invoke gc_clear_range if we have live data.
+run error
+gc_clear_range k=A end=Z ts=30
+----
+>> at end:
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) range contains live data, can't use GC clear range
+
+run ok
+del k=A ts=30
+----
+del: "A": found key true
+>> at end:
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+
+# Check that we can't invoke gc_clear_range if we are not covered by range tombstones.
+run error
+gc_clear_range k=A end=Z ts=30
+----
+>> at end:
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) found key not covered by range tombstone "A"/30.000000000,0
+
+run ok stats
+del_range_ts k=A endKey=Z ts=50
+----
+>> del_range_ts k=A endKey=Z ts=50
+stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 gc_bytes_age=+700
+>> at end:
+rangekey: A{-\x00}/[50.000000000,0=/<empty>]
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=6 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=2940
+
+# Check that we can't delete if range tombstone covering all range is above gc threshold.
+run error
+gc_clear_range k=A end=Z ts=40
+----
+>> at end:
+rangekey: A{-\x00}/[50.000000000,0=/<empty>]
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) range tombstones above gc threshold. GC=40.000000000,0, range=50.000000000,0
+
+# Check that we can delete if range tombstone covers all range.
+run stats ok
+gc_clear_range k=A end=Z ts=60
+----
+>> gc_clear_range k=A end=Z ts=60
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2940
+>> at end:
+<no data>
+stats: 
+
+# Check that is we have range tombstone coverage that covers subset but there's no other data we can still clear.
+run ok
+put k=A v=B ts=10
+del_range_ts k=A endKey=D ts=20
+----
+>> at end:
+rangekey: A{-\x00}/[20.000000000,0=/<empty>]
+data: "A"/10.000000000,0 -> /BYTES/B
+
+run stats ok
+gc_clear_range k=A end=Z ts=60
+----
+>> gc_clear_range k=A end=Z ts=60
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2720
+>> at end:
+<no data>
+stats: 
+
+# Check that gc clear range can't be performed over intents
+run ok
+with t=A
+  txn_begin ts=10
+  put k=B v=O
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "B"/10.000000000,0 -> /BYTES/O
+
+run error
+gc_clear_range k=A end=Z ts=40
+----
+>> at end:
+meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "B"/10.000000000,0 -> /BYTES/O
+error: (*withstack.withStack:) range contains live data, can't use GC clear range

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -1,98 +1,263 @@
+# 1.Clear empty range
+run ok stats
+gc_points_clear_range k=a ts=3 end=z
+----
+>> gc_points_clear_range k=a ts=3 end=z
+stats: no change
+>> at end:
+<no data>
+stats: 
+
+# 2.Clear range starting from a version under value
 run ok
-put k=A v=B ts=10
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
 ----
 >> at end:
-data: "A"/10.000000000,0 -> /BYTES/B
-
-# Check that we can't invoke gc_clear_range if we have live data.
-run error
-gc_clear_range k=A end=Z ts=30
-----
->> at end:
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) range contains live data, can't use GC clear range
-
-run ok
-del k=A ts=30
-----
-del: "A": found key true
->> at end:
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-
-# Check that we can't invoke gc_clear_range if we are not covered by range tombstones.
-run error
-gc_clear_range k=A end=Z ts=30
-----
->> at end:
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) found key not covered by range tombstone "A"/30.000000000,0
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
 
 run ok stats
-del_range_ts k=A endKey=Z ts=50
+gc_points_clear_range k=a startTs=2 end=z ts=5
 ----
->> del_range_ts k=A endKey=Z ts=50
-stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 gc_bytes_age=+700
+>> gc_points_clear_range k=a startTs=2 end=z ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
 >> at end:
-rangekey: A{-\x00}/[50.000000000,0=/<empty>]
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-stats: key_count=1 key_bytes=26 val_count=2 val_bytes=6 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=2940
+data: "a"/5.000000000,0 -> /BYTES/12
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 live_count=1 live_bytes=21
 
-# Check that we can't delete if range tombstone covering all range is above gc threshold.
-run error
-gc_clear_range k=A end=Z ts=40
+run ok
+clear_range k=a end=z
 ----
 >> at end:
-rangekey: A{-\x00}/[50.000000000,0=/<empty>]
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) range tombstones above gc threshold. GC=40.000000000,0, range=50.000000000,0
+<no data>
 
-# Check that we can delete if range tombstone covers all range.
-run stats ok
-gc_clear_range k=A end=Z ts=60
+# 3. Clear range from version under tombstone
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=5,0
 ----
->> gc_clear_range k=A end=Z ts=60
-stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2940
+del: "a": found key true
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run ok stats
+gc_points_clear_range k=a startTs=5 end=z ts=5
+----
+>> gc_points_clear_range k=a startTs=5 end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3135
 >> at end:
 <no data>
 stats: 
 
-# Check that is we have range tombstone coverage that covers subset but there's no other data we can still clear.
+# 4. Clear range from version under range tombstone
 run ok
-put k=A v=B ts=10
-del_range_ts k=A endKey=D ts=20
+put k=a v=11 ts=2,0
+del_range_ts k=a end=b ts=5,0
 ----
 >> at end:
-rangekey: A{-\x00}/[20.000000000,0=/<empty>]
-data: "A"/10.000000000,0 -> /BYTES/B
+rangekey: {a-b}/[5.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/11
 
-run stats ok
-gc_clear_range k=A end=Z ts=60
+run ok stats
+gc_points_clear_range k=a startTs=2 end=z ts=5
 ----
->> gc_clear_range k=A end=Z ts=60
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2720
+>> gc_points_clear_range k=a startTs=2 end=z ts=5
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 gc_bytes_age=-1995
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 5. Clear range up to another value
+run ok
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
+put k=c v=13 ts=5,0
+----
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "c"/5.000000000,0 -> /BYTES/13
+
+run ok stats
+gc_points_clear_range k=a startTs=2 end=c ts=5
+----
+>> gc_points_clear_range k=a startTs=2 end=c ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "c"/5.000000000,0 -> /BYTES/13
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=14 live_count=2 live_bytes=42
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 6. Clear range up to another intent
+run ok
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
+with t=A k=c
+  txn_begin ts=4,0
+  put v=1
+----
+>> at end:
+txn: "A" meta={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+meta: "c"/0,0 -> txn={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/4.000000000,0 -> /BYTES/1
+
+run ok stats
+gc_points_clear_range k=a startTs=2 end=c ts=5
+----
+>> gc_points_clear_range k=a startTs=2 end=c ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+meta: "c"/0,0 -> txn={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/4.000000000,0 -> /BYTES/1
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=64 live_count=2 live_bytes=92 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=96
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 7. Clear from before first key
+run ok
+put k=b v=11 ts=2,0
+del k=b ts=5,0
+----
+del: "b": found key true
+>> at end:
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/11
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3135
 >> at end:
 <no data>
 stats: 
 
-# Check that gc clear range can't be performed over intents
 run ok
-with t=A
-  txn_begin ts=10
-  put k=B v=O
+clear_range k=a end=z
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
-meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "B"/10.000000000,0 -> /BYTES/O
+<no data>
 
-run error
-gc_clear_range k=A end=Z ts=40
+# 8. Clear value under range tombstone
+run ok
+put k=b v=123 ts=2,0
+del_range_ts k=a end=c ts=5,0
 ----
 >> at end:
-meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "B"/10.000000000,0 -> /BYTES/O
-error: (*withstack.withStack:) range contains live data, can't use GC clear range
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-8 gc_bytes_age=-2090
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 8. Clear value under point tombstone
+run ok
+put k=b v=123 ts=2,0
+del k=b ts=5,0
+----
+del: "b": found key true
+>> at end:
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3230
+>> at end:
+<no data>
+stats: 
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 9. Clear value under point and range tombstone (checking that garbage age is correctly calculated)
+run ok
+put k=b v=123 ts=2,0
+del k=b ts=4,0
+del_range_ts k=a end=c ts=5,0
+----
+del: "b": found key true
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+data: "b"/4.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3264
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 10. Clear value under range and point tombstone (checking that garbage age is correctly calculated)
+run ok
+put k=b v=123 ts=2,0
+del_range_ts k=a end=c ts=4,0
+del k=b ts=5,0
+----
+del: "b": found key false
+>> at end:
+rangekey: {a-c}/[4.000000000,0=/<empty>]
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3250
+>> at end:
+rangekey: {a-c}/[4.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1248
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -1,0 +1,94 @@
+# 1. Fail to clear non deleted key
+run ok
+put k=a v=12 ts=2,0
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/12
+
+run error
+gc_points_clear_range k=a startTs=2 end=z ts=5
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/12
+error: (*withstack.withStack:) attempt to clear range with data "a"/2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 2. Fail to clear intent
+run ok
+with t=A k=a
+  txn_begin ts=4,0
+  put v=1
+----
+>> at end:
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/1
+
+run error
+gc_points_clear_range k=a end=z ts=5
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/1
+error: (*withstack.withStack:) attempt to clear range with data "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 3. Fail to delete key above gc threshold
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=5,0
+----
+del: "a": found key true
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run error
+gc_points_clear_range k=a startTs=2 end=z ts=4
+----
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+error: (*withstack.withStack:) attempt to clear range with data "a"/2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 4. Fail to delete key above range tombstone (checking if range tombstones are not breaking timestamp check logic)
+run ok
+put k=a v=11 ts=2,0
+del_range_ts k=a end=b ts=3,0
+put k=a v=12 ts=5,0
+----
+>> at end:
+rangekey: {a-b}/[3.000000000,0=/<empty>]
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run error
+gc_points_clear_range k=a startTs=5 end=z ts=5
+----
+>> at end:
+rangekey: {a-b}/[3.000000000,0=/<empty>]
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+error: (*withstack.withStack:) attempt to clear range with data "a"/5.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -924,6 +924,7 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"queue.gc.info.clearrangesuccess",
 					"queue.gc.info.clearrangefailed",
+					"queue.gc.info.numclearconsecutivekeys",
 				},
 			},
 			{


### PR DESCRIPTION
This commit adds range_deletion_keys parameters to GC request.
range_deletion_keys is used by GC queue to remove chunks of
consecutive keys where no new data was written above the GC
threshold and storage can optimize deletions with range
tombstones.
To support new types of keys, GCer interface is also updated
to pass provided keys down to request.

Release note: None