### PR TITLE
gc: add delete range parameters to gc request

### DIFF
--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -122,7 +122,9 @@ type Thresholder interface {
 
 // PureGCer is part of the GCer interface.
 type PureGCer interface {
-	GC(context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey) error
+	GC(context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey,
+		*roachpb.GCRequest_GCClearRangeKey,
+	) error
 }
 
 // A GCer is an abstraction used by the MVCC GC queue to carry out chunked deletions.
@@ -140,8 +142,8 @@ var _ GCer = NoopGCer{}
 func (NoopGCer) SetGCThreshold(context.Context, Threshold) error { return nil }
 
 // GC implements storage.GCer.
-func (NoopGCer) GC(
-	context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey,
+func (NoopGCer) GC(context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey,
+	*roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	return nil
 }
@@ -425,7 +427,7 @@ func processReplicatedKeyRange(
 		}
 		// If limit was reached, delegate to GC'r to remove collected batch.
 		if shouldSendBatch {
-			if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+			if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 				if errors.Is(err, ctx.Err()) {
 					return err
 				}
@@ -448,7 +450,7 @@ func processReplicatedKeyRange(
 		log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
 	}
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 			return err
 		}
 	}
@@ -820,7 +822,7 @@ func (b *rangeKeyBatcher) flushPendingFragments(ctx context.Context) error {
 		}
 		b.pending = b.pending[:0]
 		b.pendingSize = 0
-		return b.gcer.GC(ctx, nil, toSend)
+		return b.gcer.GC(ctx, nil, toSend, nil)
 	}
 	return nil
 }
@@ -901,7 +903,7 @@ func (b *batchingInlineGCer) FlushingAdd(ctx context.Context, key roachpb.Key) {
 }
 
 func (b *batchingInlineGCer) Flush(ctx context.Context) {
-	err := b.gcer.GC(ctx, b.gcKeys, nil)
+	err := b.gcer.GC(ctx, b.gcKeys, nil, nil)
 	b.gcKeys = nil
 	b.size = 0
 	if err != nil {

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -36,13 +36,14 @@ type gcIterator struct {
 }
 
 func makeGCIterator(
-	desc *roachpb.RangeDescriptor, snap storage.Reader, threshold hlc.Timestamp,
+	desc *roachpb.RangeDescriptor, snap storage.Reader, threshold hlc.Timestamp, collectUserKeySpace bool,
 ) gcIterator {
 	return gcIterator{
 		it: rditer.NewReplicaMVCCDataIterator(desc, snap, rditer.ReplicaDataIteratorOptions{
-			Reverse:  true,
-			IterKind: storage.MVCCKeyAndIntentsIterKind,
-			KeyTypes: storage.IterKeyTypePointsAndRanges,
+			Reverse:             true,
+			IterKind:            storage.MVCCKeyAndIntentsIterKind,
+			KeyTypes:            storage.IterKeyTypePointsAndRanges,
+			ExcludeUserKeySpace: !collectUserKeySpace,
 		}),
 		threshold: threshold,
 	}

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -151,7 +151,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys, nil)
+							err := gcer.GC(ctx, batchGCKeys, nil, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -210,7 +210,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -720,6 +720,7 @@ type fakeGCer struct {
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
 	gcRangeKeyBatches [][]roachpb.GCRequest_GCRangeKey
+	gcRangeDeleteKeys []roachpb.GCRequest_GCClearRangeKey
 	threshold         Threshold
 	intents           []roachpb.Intent
 	batches           [][]roachpb.Intent
@@ -739,13 +740,16 @@ func (f *fakeGCer) SetGCThreshold(ctx context.Context, t Threshold) error {
 	return nil
 }
 
-func (f *fakeGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+func (f *fakeGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey, clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
 	}
 	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	if clearRangeKey != nil {
+		f.gcRangeDeleteKeys = append(f.gcRangeDeleteKeys, *clearRangeKey)
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -55,8 +55,8 @@ type collectingGCer struct {
 	keys [][]roachpb.GCRequest_GCKey
 }
 
-func (c *collectingGCer) GC(
-	_ context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+func (c *collectingGCer) GC(_ context.Context, keys []roachpb.GCRequest_GCKey,
+	_ []roachpb.GCRequest_GCRangeKey, _ *roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	c.keys = append(c.keys, keys)
 	return nil

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1358,6 +1358,12 @@ The count is emitted by the leaseholder of each range.
 		Measurement: "Intent Resolutions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaGCUsedClearRange = metric.Metadata{
+		Name:        "queue.gc.info.clearrange",
+		Help:        "Number of successful calls to perform ClearRange operation on full range",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Slow request metrics.
 	metaLatchRequests = metric.Metadata{
@@ -1817,6 +1823,7 @@ type StoreMetrics struct {
 	GCResolveFailed *metric.Counter
 	// Failures resolving intents that belong to local transactions.
 	GCTxnIntentsResolveFailed *metric.Counter
+	GCUsedClearRange          *metric.Counter
 
 	// Slow request counts.
 	SlowLatchRequests *metric.Gauge
@@ -2329,6 +2336,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		GCResolveSuccess:             metric.NewCounter(metaGCResolveSuccess),
 		GCResolveFailed:              metric.NewCounter(metaGCResolveFailed),
 		GCTxnIntentsResolveFailed:    metric.NewCounter(metaGCTxnIntentsResolveFailed),
+		GCUsedClearRange:             metric.NewCounter(metaGCUsedClearRange),
 
 		// Wedge request counters.
 		SlowLatchRequests: metric.NewGauge(metaLatchRequests),

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -666,6 +666,7 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 	metrics.GCAbortSpanGCNum.Inc(int64(info.AbortSpanGCNum))
 	metrics.GCPushTxn.Inc(int64(info.PushTxn))
 	metrics.GCResolveTotal.Inc(int64(info.ResolveTotal))
+	metrics.GCUsedClearRange.Inc(int64(info.FastPathOperations))
 }
 
 // timer returns a constant duration to space out GC processing

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -483,15 +483,16 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 	return r.send(ctx, req)
 }
 
-func (r *replicaGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+func (r *replicaGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey, clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
 ) error {
-	if len(keys) == 0 && len(rangeKeys) == 0 {
+	if len(keys) == 0 && len(rangeKeys) == 0 && clearRangeKey == nil {
 		return nil
 	}
 	req := r.template()
 	req.Keys = keys
 	req.RangeKeys = rangeKeys
+	req.ClearRangeKey = clearRangeKey
 	return r.send(ctx, req)
 }
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -973,11 +973,24 @@ message GCRequest {
   message GCRangeKey {
     bytes start_key = 1 [(gogoproto.casttype) = "Key"];
     bytes end_key = 2 [(gogoproto.casttype) = "Key"];
-    util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
   }
   repeated GCRangeKey range_keys = 6 [(gogoproto.nullable) = false];
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
+
+  // Range clear request. Each request covers data starting from an MVCC version
+  // down to the full key at the end of the range. This approach allows us to
+  // delete data from the key which has non garbage versions down to the next
+  // key that has non garbage versions along with all the range tombstones.
+  message GCClearRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp start_key_timestamp = 2 [(gogoproto.nullable) = false];
+    bytes end_key = 3 [(gogoproto.casttype) = "Key"];
+  }
+  // range_deletion_keys contains zero or one range that would be deleted using
+  // storage range delete operation. Note that this range must not have any
+  // data newer than GC threshold or the request will fail.
+  GCClearRangeKey clear_range_key = 7;
 
   reserved 5;
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4891,6 +4891,71 @@ func MVCCGarbageCollectRangeKeys(
 	return nil
 }
 
+// MVCCGarbageCollectWholeRange removes all the range data and resets counters.
+// It only does so if data is completely covered by range keys
+func MVCCGarbageCollectWholeRange(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	start, end roachpb.Key,
+	gcThreshold hlc.Timestamp,
+) error {
+	if ms.ContainsEstimates == 0 && ms.LiveCount > 0 {
+		return errors.Errorf("range contains live data, can't use GC clear range")
+	}
+	if err := CheckRangeEmptiness(ctx, rw, start, end, gcThreshold); err != nil {
+		return err
+	}
+	if err := rw.ClearRawRange(start, end, true, true); err != nil {
+		return err
+	}
+	if ms != nil {
+		// Reset point and range counters as we deleted the whole range.
+		ms.LiveCount = 0
+		ms.LiveBytes = 0
+		ms.KeyCount = 0
+		ms.ValCount = 0
+		ms.RangeKeyCount = 0
+		ms.RangeKeyBytes = 0
+		ms.RangeValCount = 0
+		ms.RangeValBytes = 0
+	}
+	return nil
+}
+
+func CheckRangeEmptiness(ctx context.Context,
+	rw Reader, start, end roachpb.Key, gcThreshold hlc.Timestamp,
+) error {
+	iter := NewMVCCIncrementalIterator(rw, MVCCIncrementalIterOptions{
+		KeyTypes:             IterKeyTypePointsAndRanges,
+		StartKey:             start,
+		EndKey:               end,
+		RangeKeyMaskingBelow: gcThreshold,
+		IntentPolicy:         MVCCIncrementalIterIntentPolicyError,
+	})
+	defer iter.Close()
+	iter.SeekGE(MVCCKey{Key: start})
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+		hasPoint, hasRange := iter.HasPointAndRange()
+		if hasPoint {
+			return errors.Errorf("found key not covered by range tombstone %s", iter.UnsafeKey())
+		}
+		if hasRange {
+			newest := iter.RangeKeys().Newest()
+			if gcThreshold.Less(newest) {
+				return errors.Errorf("range tombstones above gc threshold. GC=%s, range=%s",
+					gcThreshold.String(), newest.String())
+			}
+		}
+	}
+	return nil
+}
+
 // MVCCFindSplitKey finds a key from the given span such that the left side of
 // the split is roughly targetSize bytes. The returned key will never be chosen
 // from the key ranges listed in keys.NoSplitSpans.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -103,6 +103,8 @@ var sstIterVerify = util.ConstantWithMetamorphicTestBool("mvcc-histories-sst-ite
 // clear_range    k=<key> end=<key>
 // clear_rangekey k=<key> end=<key> ts=<int>[,<int>]
 //
+// gc_clear_range k=<key> end=<key> startTs=<int>[,<int>] ts=<int>[,<int>]
+//
 // sst_put            [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> [v=<string>]
 // sst_put_rangekey   ts=<int>[,<int>] [localTS=<int>[,<int>]] k=<key> end=<key>
 // sst_clear_range    k=<key> end=<key>
@@ -656,6 +658,7 @@ var commands = map[string]cmd{
 	"del_range_pred": {typDataUpdate, cmdDeleteRangePredicate},
 	"export":         {typReadOnly, cmdExport},
 	"get":            {typReadOnly, cmdGet},
+	"gc_clear_range": {typDataUpdate, cmdGCClearRange},
 	"increment":      {typDataUpdate, cmdIncrement},
 	"initput":        {typDataUpdate, cmdInitPut},
 	"merge":          {typDataUpdate, cmdMerge},
@@ -901,6 +904,15 @@ func cmdClearRangeKey(e *evalCtx) error {
 	key, endKey := e.getKeyRange()
 	ts := e.getTs(nil)
 	return e.engine.ClearMVCCRangeKey(MVCCRangeKey{StartKey: key, EndKey: endKey, Timestamp: ts})
+}
+
+func cmdGCClearRange(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	gcTs := e.getTs(nil)
+	return e.withWriter("gc_clear_range", func(rw ReadWriter) error {
+		return MVCCGarbageCollectWholeRange(e.ctx, rw, e.ms, key, endKey, gcTs,
+			key.Prevish(99), endKey.Next())
+	})
 }
 
 func cmdCPut(e *evalCtx) error {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5277,6 +5277,11 @@ func pt(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
 	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts), Value: val}}
 }
 
+// tb creates a point tombstone.
+func tb(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
+	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts)}}
+}
+
 // txn wraps point update and adds transaction to it for intent creation.
 func txn(d rangeTestDataItem) rangeTestDataItem {
 	ts := d.point.Key.Timestamp
@@ -5812,6 +5817,12 @@ func rangesFromRequests(
 	return collectableKeys
 }
 
+func clearRangesFromRequest(
+	rangeKey roachpb.GCRequest_GCClearRangeKey,
+) (start, end roachpb.Key, timestamp hlc.Timestamp, leftPeek, rightPeek roachpb.Key) {
+	return rangeKey.StartKey, rangeKey.EndKey, rangeKey.StartKeyTimestamp, rangeKey.StartKey.Prevish(99), rangeKey.EndKey.Next()
+}
+
 func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5913,6 +5924,244 @@ func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 					d.before.populateEngine(t, engine, nil)
 					rangeKeys := rangesFromRequests(rangeStart, rangeEnd, d.request)
 					err := MVCCGarbageCollectRangeKeys(ctx, engine, nil, rangeKeys)
+					require.Errorf(t, err, "expected error '%s' but found none", d.error)
+					require.True(t, testutils.IsError(err, d.error),
+						"expected error '%s' found '%s'", d.error, err)
+				})
+			}
+		})
+	}
+}
+
+func TestMVCCGarbageCollectClearRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyB := mkKey("bb")
+	keyC := mkKey("ccc")
+	keyD := mkKey("dddd")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts1 := mkTs(1)
+	ts2 := mkTs(2)
+	ts3 := mkTs(3)
+	ts4 := mkTs(4)
+	tsMax := mkTs(9)
+
+	mkGCReq := func(start roachpb.Key, startTs hlc.Timestamp, end roachpb.Key) roachpb.GCRequest_GCClearRangeKey {
+		return roachpb.GCRequest_GCClearRangeKey{
+			StartKey:          start,
+			StartKeyTimestamp: startTs,
+			EndKey:            end,
+		}
+	}
+
+	testData := []struct {
+		name string
+		// Note that range test data should be in ascending order (valid writes).
+		before  rangeTestData
+		request roachpb.GCRequest_GCClearRangeKey
+		after   rangeTestData
+		// Optional start and end range for tests that want to restrict default
+		// key range.
+		rangeStart roachpb.Key
+		rangeEnd   roachpb.Key
+	}{
+		{
+			name: "single point",
+			before: rangeTestData{
+				pt(keyB, ts2),
+				tb(keyB, ts3),
+			},
+			request: mkGCReq(keyB, ts2, keyD),
+			after: rangeTestData{
+				tb(keyB, ts3),
+			},
+		},
+		{
+			name: "clear over range tombstone deleted points",
+			before: rangeTestData{
+				pt(keyB, ts2),
+				rng(keyA, keyD, ts4),
+			},
+			request: mkGCReq(keyA, ts2, keyD),
+			after: rangeTestData{
+				rng(keyA, keyA.Next(), ts4),
+			},
+		},
+		{
+			name: "clear over multiple versions",
+			before: rangeTestData{
+				pt(keyB, ts1),
+				pt(keyB, ts2),
+				tb(keyB, ts3),
+				tb(keyB, ts4),
+				pt(keyC, ts1),
+				tb(keyC, ts2),
+				pt(keyC, ts3),
+				tb(keyC, ts4),
+			},
+			request: mkGCReq(keyA, hlc.Timestamp{}, keyD),
+			after: rangeTestData{},
+		},
+	}
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			for _, d := range testData {
+				t.Run(d.name, func(t *testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Populate range descriptor defaults.
+					if len(d.rangeStart) == 0 {
+						d.rangeStart = rangeStart
+					}
+					if len(d.rangeEnd) == 0 {
+						d.rangeEnd = rangeEnd
+					}
+
+					var ms enginepb.MVCCStats
+					d.before.populateEngine(t, engine, &ms)
+
+					start, end, startTs, leftPeek, rightPeek := clearRangesFromRequest(d.request)
+					require.NoError(t,
+						MVCCGarbageCollectWholeRange(ctx, engine, &ms, start, end, startTs, tsMax, leftPeek,
+							rightPeek),
+						"failed to run mvcc range tombstone garbage collect")
+
+					expected := engineImpl.create()
+					defer expected.Close()
+					var expMs enginepb.MVCCStats
+					d.after.populateEngine(t, expected, &expMs)
+
+					rks := scanRangeKeys(t, engine)
+					expRks := scanRangeKeys(t, expected)
+					require.EqualValues(t, expRks, rks)
+
+					ks := scanPointKeys(t, engine)
+					expKs := scanPointKeys(t, expected)
+					require.EqualValues(t, expKs, ks)
+
+					ms.AgeTo(tsMax.WallTime)
+					it := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+						KeyTypes:   IterKeyTypePointsAndRanges,
+						LowerBound: d.rangeStart,
+						UpperBound: d.rangeEnd,
+					})
+					expMs, err := ComputeStatsForRange(it, rangeStart, rangeEnd, tsMax.WallTime)
+					require.NoError(t, err, "failed to compute stats for range")
+					require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
+				})
+			}
+		})
+	}
+}
+
+func TestMVCCGarbageCollectClearRangeFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyD := mkKey("dddd")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts0 := mkTs(0)
+	ts1 := mkTs(1)
+	tsGC := mkTs(5)
+	tsMax := mkTs(9)
+
+	mkGCReq := func(start roachpb.Key, startTs hlc.Timestamp, end roachpb.Key) roachpb.GCRequest_GCClearRangeKey {
+		return roachpb.GCRequest_GCClearRangeKey{
+			StartKey:          start,
+			StartKeyTimestamp: startTs,
+			EndKey:            end,
+		}
+	}
+
+	testData := []struct {
+		name string
+		// Note that range test data should be in ascending order (valid writes).
+		before  rangeTestData
+		request roachpb.GCRequest_GCClearRangeKey
+		error   string
+		// Optional start and end range for tests that want to restrict default
+		// key range.
+		rangeStart roachpb.Key
+		rangeEnd   roachpb.Key
+	}{
+		{
+			name: "clear over intent",
+			before: rangeTestData{
+				txn(pt(keyA, ts1)),
+			},
+			request: mkGCReq(keyA, ts0, keyD),
+			error: `attempt to clear range with data /Table/42/"a"`,
+		},
+		{
+			name: "clear over non-deleted data",
+			before: rangeTestData{
+				pt(keyA, ts1),
+			},
+			request: mkGCReq(keyA, ts1, keyD),
+			error: `attempt to clear range with data /Table/42/"a"/1.000000000,0`,
+		},
+		{
+			name: "clear over recent range tombstone",
+			before: rangeTestData{
+				rng(keyA, keyD, tsMax),
+			},
+			request: mkGCReq(keyA, ts1, keyD),
+			error: `attempt to clear range with data /Table/42/"{a"-dddd"}/9.000000000,0`,
+		},
+	}
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			for _, d := range testData {
+				t.Run(d.name, func(t *testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Populate range descriptor defaults.
+					if len(d.rangeStart) == 0 {
+						d.rangeStart = rangeStart
+					}
+					if len(d.rangeEnd) == 0 {
+						d.rangeEnd = rangeEnd
+					}
+
+					var ms enginepb.MVCCStats
+					d.before.populateEngine(t, engine, &ms)
+
+					start, end, startTs, leftPeek, rightPeek := clearRangesFromRequest(d.request)
+					err := MVCCGarbageCollectWholeRange(ctx, engine, &ms, start, end, startTs, tsGC, leftPeek,
+							rightPeek)
 					require.Errorf(t, err, "expected error '%s' but found none", d.error)
 					require.True(t, testutils.IsError(err, d.error),
 						"expected error '%s' found '%s'", d.error, err)

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -1,0 +1,235 @@
+# Each error uses distinct data set and multiple tests are combined in this file.
+# ~~~ - gc clear range ops (test case number embedded for clarity)
+#  5  ~8~~~   ~7~~~   ~6~~~   ~5~~~~~~    ~4~~~~~~    ~3~~~           ~2~~~   ~1~~~      ~9~~
+#  4  x               o---o   x   x       o---o       o-------o   o-------o           o-----------o
+#  3                          x   55      888
+#  2  1       o---o   22      3   x       o---o       o-------o   o-------o           o-----------o
+#  1                          44  6       7
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   nn  o   p   q   r   s   t   u   v   w   x
+
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=4,0
+del_range_ts k=c end=d ts=2,0
+put k=e v=22 ts=2,0
+del_range_ts k=e end=f ts=4,0
+with k=g
+  put v=44 ts=1,0
+  put v=3 ts=2,0
+  del ts=3,0
+  del ts=4,0
+with k=h
+  put v=5 ts=1,0
+  del ts=2,0
+  put v=66 ts=3,0
+  del ts=4,0
+with k=j
+  put v=7 ts=1,0
+  del_range_ts end=k ts=2,0
+  put v=888 ts=3,0
+  del_range_ts end=k ts=4,0
+with k=m end=o
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+with k=p end=r
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+with k=u end=x
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+----
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-r}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+
+#1
+run stats
+gc_clear_range k=s end=t ts=5,0
+----
+>> gc_clear_range k=s end=t ts=5,0
+stats: no change
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-r}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=114 range_val_count=10 gc_bytes_age=32326
+
+#2
+run stats
+gc_clear_range k=q end=r ts=5,0
+----
+>> gc_clear_range k=q end=r ts=5,0
+stats: no change
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=114 range_val_count=10 gc_bytes_age=32326
+
+#3
+run stats
+gc_clear_range k=m end=nn ts=5,0
+----
+>> gc_clear_range k=m end=nn ts=5,0
+stats: range_key_bytes=+1 gc_bytes_age=+96
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=115 range_val_count=10 gc_bytes_age=32422
+
+#4
+run stats
+gc_clear_range k=j end=l ts=5,0
+----
+>> gc_clear_range k=j end=l ts=5,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-14 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-6006
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+stats: key_count=4 key_bytes=140 val_count=11 val_bytes=40 range_key_count=5 range_key_bytes=93 range_val_count=8 gc_bytes_age=26416
+
+run stats
+gc_clear_range k=g end=i ts=5,0
+----
+>> gc_clear_range k=g end=i ts=5,0
+stats: key_count=-2 key_bytes=-100 val_count=-8 val_bytes=-26 gc_bytes_age=-12224
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=14 range_key_count=5 range_key_bytes=93 range_val_count=8 gc_bytes_age=14192
+
+run stats
+gc_clear_range k=e end=f ts=5,0
+----
+>> gc_clear_range k=e end=f ts=5,0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-3264
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=7 range_key_count=4 range_key_bytes=80 range_val_count=7 gc_bytes_age=10928
+
+run stats
+gc_clear_range k=c end=d ts=5,0
+----
+>> gc_clear_range k=c end=d ts=5,0
+stats: range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-1274
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=7 range_key_count=3 range_key_bytes=67 range_val_count=6 gc_bytes_age=9654
+
+run stats
+gc_clear_range k=a end=b ts=5,0
+----
+>> gc_clear_range k=a end=b ts=5,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3168
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+stats: range_key_count=3 range_key_bytes=67 range_val_count=6 gc_bytes_age=6486
+
+run stats
+gc_clear_range k=v end=w ts=5,0
+----
+>> gc_clear_range k=v end=w ts=5,0
+stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2130
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {w-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+stats: range_key_count=4 range_key_bytes=89 range_val_count=8 gc_bytes_age=8616

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -1,0 +1,122 @@
+# Each error uses distinct data set and multiple tests are combined in this file.
+#  5                  o-------o   x       v4      [v5]
+#  4
+#  3  ~~~~~   ~~~~~       ~~~~~   ~~~~~   ~~~~~   ~~~~~  Clear ranges at GC threshold
+#  2
+#  1  [v1]    v2                  v3
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o
+
+run ok
+with t=A k=a
+  txn_begin ts=1,0
+  put  v=1
+put  k=c v=2 ts=1,0
+del_range_ts  k=e end=g ts=5,0
+put  k=h v=3 ts=1,0
+del  k=h ts=5,0
+put  k=j v=4 ts=5,0
+with t=B k=l
+  txn_begin ts=5,0
+  put v=5
+----
+>> at end:
+txn: "B" meta={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+
+run error
+gc_clear_range k=a end=b startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "a"
+
+run error
+gc_clear_range k=c end=d startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "c"/1.000000000,0
+
+run error
+gc_clear_range k=h end=i startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "h"/5.000000000,0
+
+run error
+gc_clear_range k=f end=g startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data {e\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff-g}/5.000000000,0
+
+run error
+gc_clear_range k=j end=k startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "j"/5.000000000,0
+
+run error
+gc_clear_range k=l end=m startTs=0,0 ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "l"

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_partial
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_partial
@@ -1,0 +1,396 @@
+# Each error uses distinct data set and multiple tests are combined in this file.
+# 5
+# 4 [v1] [v4]           [v9] v10       v13
+# 3 x    x    x              x                        x                   x              o---------o       o-------o
+# 2 v2   v5   v88            v11  x    o---------o         o----o         v17       o--------------o   o---------------o
+# 1 v3   v6                       v12  v14  v15       v16                                     v18              v19
+#   a    b    c    d    e    f    g    h    i    j    k    l    m    n    o    p    q    r    s    t   u   v   w   x   z
+
+run ok
+# for case #1
+with k=a
+  put v=v3 ts=1,0
+  put v=v2 ts=2,0
+  del ts=3,0
+  with t=A
+    txn_begin ts=4,0
+    put v=v1
+# for case #2
+with k=b
+  put v=v6 ts=1,0
+  put v=v5 ts=2,0
+  del ts=3,0
+  with t=B
+    txn_begin ts=4,0
+    put v=v4
+with k=c
+  put v=v99 ts=2,0
+  del ts=3,0
+# for case #3
+with k=e t=C
+  txn_begin ts=4,0
+  put v=v5
+# for case #4
+with k=f
+  put v=v11 ts=2,0
+  del ts=3,0
+  put v=v10 ts=4,0
+with k=g
+  put v=v12 ts=1,0
+  del ts=2,0
+# for case #5
+put k=h v=v14 ts=1,0
+put k=i v=v15 ts=1,0
+del_range_ts k=h end=j ts=2,0
+put k=h v=v13 ts=4,0
+# for case #6
+with k=k
+  put k=k v=16 ts=1,0
+  del ts=3,0
+del_range_ts k=l end=m ts=2,0
+# for case #7
+with k=o
+  put v=17 ts=2,0
+  del ts=3,0
+# for case #8
+put k=s v=v18 ts=1,0
+del_range_ts k=q end=t ts=2,0
+del_range_ts k=r end=t ts=3,0
+# for case #9
+put k=w v=v19 ts=1,0
+del_range_ts k=u end=z ts=2,0
+del_range_ts k=v end=x ts=3,0
+----
+>> at end:
+txn: "C" meta={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+rangekey: {h-j}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/v2
+data: "a"/1.000000000,0 -> /BYTES/v3
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/v5
+data: "b"/1.000000000,0 -> /BYTES/v6
+data: "c"/3.000000000,0 -> /<empty>
+data: "c"/2.000000000,0 -> /BYTES/v99
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/v11
+data: "g"/2.000000000,0 -> /<empty>
+data: "g"/1.000000000,0 -> /BYTES/v12
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "h"/1.000000000,0 -> /BYTES/v14
+data: "i"/1.000000000,0 -> /BYTES/v15
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+
+#1
+run ok stats
+gc_clear_range k=a end=b startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=a end=b startTs=2,0 ts=3,0
+stats: key_bytes=-24 val_count=-2 val_bytes=-14 gc_bytes_age=-3705
+>> at end:
+rangekey: {h-j}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/v5
+data: "b"/1.000000000,0 -> /BYTES/v6
+data: "c"/3.000000000,0 -> /<empty>
+data: "c"/2.000000000,0 -> /BYTES/v99
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/v11
+data: "g"/2.000000000,0 -> /<empty>
+data: "g"/1.000000000,0 -> /BYTES/v12
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "h"/1.000000000,0 -> /BYTES/v14
+data: "i"/1.000000000,0 -> /BYTES/v15
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=12 key_bytes=300 val_count=23 val_bytes=274 range_key_count=7 range_key_bytes=109 range_val_count=9 live_count=5 live_bytes=260 gc_bytes_age=41253 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#2
+run ok stats
+gc_clear_range k=b end=e startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=b end=e startTs=2,0 ts=3,0
+stats: key_count=-1 key_bytes=-50 val_count=-4 val_bytes=-22 gc_bytes_age=-7003
+>> at end:
+rangekey: {h-j}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/v11
+data: "g"/2.000000000,0 -> /<empty>
+data: "g"/1.000000000,0 -> /BYTES/v12
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "h"/1.000000000,0 -> /BYTES/v14
+data: "i"/1.000000000,0 -> /BYTES/v15
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=252 range_key_count=7 range_key_bytes=109 range_val_count=9 live_count=5 live_bytes=260 gc_bytes_age=34250 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#3
+run ok stats
+gc_clear_range k=e end=f startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=e end=f startTs=2,0 ts=3,0
+stats: no change
+>> at end:
+rangekey: {h-j}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/v11
+data: "g"/2.000000000,0 -> /<empty>
+data: "g"/1.000000000,0 -> /BYTES/v12
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "h"/1.000000000,0 -> /BYTES/v14
+data: "i"/1.000000000,0 -> /BYTES/v15
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=252 range_key_count=7 range_key_bytes=109 range_val_count=9 live_count=5 live_bytes=260 gc_bytes_age=34250 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#4
+run ok stats
+gc_clear_range k=f end=h startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=f end=h startTs=2,0 ts=3,0
+stats: key_count=-1 key_bytes=-38 val_count=-3 val_bytes=-16 gc_bytes_age=-5272
+>> at end:
+rangekey: {h-j}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "h"/1.000000000,0 -> /BYTES/v14
+data: "i"/1.000000000,0 -> /BYTES/v15
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=10 key_bytes=212 val_count=16 val_bytes=236 range_key_count=7 range_key_bytes=109 range_val_count=9 live_count=5 live_bytes=260 gc_bytes_age=28978 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#5
+run ok stats
+gc_clear_range k=h end=j startTs=1,0 ts=3,0
+----
+>> gc_clear_range k=h end=j startTs=1,0 ts=3,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-16 range_key_bytes=+1 gc_bytes_age=-4018
+>> at end:
+rangekey: h{-\x00}/[2.000000000,0=/<empty>]
+rangekey: {l-m}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "k"/3.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/16
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=9 key_bytes=186 val_count=14 val_bytes=220 range_key_count=7 range_key_bytes=110 range_val_count=9 live_count=5 live_bytes=260 gc_bytes_age=24960 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#6
+run ok stats
+gc_clear_range k=k end=m startTs=1,0 ts=3,0
+----
+>> gc_clear_range k=k end=m startTs=1,0 ts=3,0
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-3117
+>> at end:
+rangekey: h{-\x00}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "k"/3.000000000,0 -> /<empty>
+data: "o"/3.000000000,0 -> /<empty>
+data: "o"/2.000000000,0 -> /BYTES/17
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=9 key_bytes=174 val_count=13 val_bytes=213 range_key_count=6 range_key_bytes=97 range_val_count=8 live_count=5 live_bytes=260 gc_bytes_age=21843 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#7
+run ok stats
+gc_clear_range k=n end=p startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=n end=p startTs=2,0 ts=3,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3201
+>> at end:
+rangekey: h{-\x00}/[2.000000000,0=/<empty>]
+rangekey: {q-r}/[2.000000000,0=/<empty>]
+rangekey: {r-t}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "k"/3.000000000,0 -> /<empty>
+data: "s"/1.000000000,0 -> /BYTES/v18
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=8 key_bytes=148 val_count=11 val_bytes=206 range_key_count=6 range_key_bytes=97 range_val_count=8 live_count=5 live_bytes=260 gc_bytes_age=18642 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#8
+run ok stats
+gc_clear_range k=p end=t startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=p end=t startTs=2,0 ts=3,0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-8 range_key_count=-2 range_key_bytes=-35 range_val_count=-3 gc_bytes_age=-5573
+>> at end:
+rangekey: h{-\x00}/[2.000000000,0=/<empty>]
+rangekey: {u-v}/[2.000000000,0=/<empty>]
+rangekey: {v-x}/[3.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "k"/3.000000000,0 -> /<empty>
+data: "w"/1.000000000,0 -> /BYTES/v19
+stats: key_count=7 key_bytes=134 val_count=10 val_bytes=198 range_key_count=4 range_key_bytes=62 range_val_count=5 live_count=5 live_bytes=260 gc_bytes_age=13069 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288
+
+#9
+run ok stats
+gc_clear_range k=u end=x startTs=2,0 ts=3,0
+----
+>> gc_clear_range k=u end=x startTs=2,0 ts=3,0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-8 range_key_count=-1 range_key_bytes=-21 range_val_count=-2 gc_bytes_age=-4201
+>> at end:
+rangekey: h{-\x00}/[2.000000000,0=/<empty>]
+rangekey: u{-\x00}/[2.000000000,0=/<empty>]
+rangekey: {x-z}/[2.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/v1
+data: "a"/3.000000000,0 -> /<empty>
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/4.000000000,0 -> /BYTES/v4
+data: "b"/3.000000000,0 -> /<empty>
+meta: "e"/0,0 -> txn={id=00000000 key="e" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "e"/4.000000000,0 -> /BYTES/v5
+data: "f"/4.000000000,0 -> /BYTES/v10
+data: "f"/3.000000000,0 -> /<empty>
+data: "h"/4.000000000,0 -> /BYTES/v13
+data: "k"/3.000000000,0 -> /<empty>
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=190 range_key_count=3 range_key_bytes=41 range_val_count=3 live_count=5 live_bytes=260 gc_bytes_age=8868 intent_count=3 intent_bytes=57 separated_intent_count=3 intent_age=288

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -891,6 +891,12 @@ var charts = []sectionDescription{
 					"queue.gc.info.transactionspangcstaging",
 				},
 			},
+			{
+				Title: "GC Clear Range",
+				Metrics: []string{
+					"queue.gc.info.clearrange",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This commit adds range_deletion_keys parameters to GC request.
range_deletion_keys is used by GC queue to remove chunks of
consecutive keys where no new data was written above the GC
threshold and storage can optimize deletions with range
tombstones.
To support new types of keys, GCer interface is also updated
to pass provided keys down to request.

Release note: None